### PR TITLE
Update filter format

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -83,13 +83,51 @@ network:
 ```
 
 ### Process
-
+Process can be configured to have multiple filters.  Each filter operates
+on an and basis.  If a process matches any one filter then it will be 
+included, even if another filter explicitly excludes it.
 ```yaml
 process:
-  <include|exclude>:
-    names: [ <process name>, ... ]
-    match_type: <strict|regexp>
   mute_process_name_error: <true|false>
+  filters:
+    -
+      <include_executable_name|exclude_executable_name>:
+        match_type: <strict|regexp>
+        executable_name: [<executable name>, ... ]
+      <include_executable_path|exclude_executable_path>:
+        match_type: <strict|regexp>
+        executable_path: [<executable path>, ... ]
+      <include_process_command|exclude_process_command>:
+        match_type: <strict|regexp>
+        process_command: [<command>, ... ]
+      <include_process_command_line|exclude_process_command_line>:
+        match_type: <strict|regexp>
+        process_command_line: [<command line>, ... ]
+      <include_process_owner|exclude_process_owner>:
+        match_type: <strict|regexp>
+        process_owner: [<owner>, ... ]
+      <include_process_pid|exclude_process_pid>:
+        process_pid: [<pid>, ... ]        
+    -
+      <include_executable_name|exclude_executable_name>:
+        match_type: <strict|regexp>
+        executable_name: [<executable name>, ... ]
+      <include_executable_path|exclude_executable_path>:
+        match_type: <strict|regexp>
+        executable_path: [<executable path>, ... ]
+      <include_process_command|exclude_process_command>:
+        match_type: <strict|regexp>
+        process_command: [<command>, ... ]
+      <include_process_command_line|exclude_process_command_line>:
+        match_type: <strict|regexp>
+        process_command_line: [<command line>, ... ]
+      <include_process_owner|exclude_process_owner>:
+        match_type: <strict|regexp>
+        process_owner: [<owner>, ... ]
+      <include_process_pid|exclude_process_pid>:
+        process_pid: [<pid>, ... ]        
+    -
+      <create as many filters as desired>:
 ```
 
 ## Advanced Configuration

--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -88,9 +88,14 @@ func TestLoadConfig(t *testing.T) {
 			pagingscraper.TypeStr:    (&pagingscraper.Factory{}).CreateDefaultConfig(),
 			processscraper.TypeStr: (func() internal.Config {
 				cfg := (&processscraper.Factory{}).CreateDefaultConfig()
-				cfg.(*processscraper.Config).Include = processscraper.MatchConfig{
-					Names:  []string{"test2", "test3"},
-					Config: filterset.Config{MatchType: "regexp"},
+
+				cfg.(*processscraper.Config).Filters = []processscraper.FilterConfig{
+					processscraper.FilterConfig{
+						IncludeExecutableNames: processscraper.ExecutableNameMatchConfig{
+							ExecutableNames: []string{"test2", "test3"},
+							Config:          filterset.Config{MatchType: filterset.Regexp},
+						},
+					},
 				}
 				return cfg
 			})(),

--- a/receiver/hostmetricsreceiver/internal/filterhelper/filtercreator.go
+++ b/receiver/hostmetricsreceiver/internal/filterhelper/filtercreator.go
@@ -15,7 +15,7 @@ func NewIncludeFilterHelper(items []string, filterSet *filterset.Config, typ str
 	return newFilterHelper(items, filterSet, includeKey, typ)
 }
 
-// NewIncludeFilterHelper creates a FilterSet based on a config
+// NewExcludeFilterHelper creates a FilterSet based on a config
 func NewExcludeFilterHelper(items []string, filterSet *filterset.Config, typ string) (filterset.FilterSet, error) {
 	return newFilterHelper(items, filterSet, excludeKey, typ)
 }

--- a/receiver/hostmetricsreceiver/internal/filterhelper/filtercreator.go
+++ b/receiver/hostmetricsreceiver/internal/filterhelper/filtercreator.go
@@ -10,10 +10,12 @@ const (
 	includeKey = "include"
 )
 
+// NewIncludeFilterHelper creates a FilterSet based on a config
 func NewIncludeFilterHelper(items []string, filterSet *filterset.Config, typ string) (filterset.FilterSet, error) {
 	return newFilterHelper(items, filterSet, includeKey, typ)
 }
 
+// NewIncludeFilterHelper creates a FilterSet based on a config
 func NewExcludeFilterHelper(items []string, filterSet *filterset.Config, typ string) (filterset.FilterSet, error) {
 	return newFilterHelper(items, filterSet, excludeKey, typ)
 }
@@ -30,4 +32,3 @@ func newFilterHelper(items []string, filterSet *filterset.Config, typ string, fi
 	}
 	return filter, nil
 }
-

--- a/receiver/hostmetricsreceiver/internal/filterhelper/filtercreator.go
+++ b/receiver/hostmetricsreceiver/internal/filterhelper/filtercreator.go
@@ -1,0 +1,33 @@
+package filterhelper
+
+import (
+	"fmt"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
+)
+
+const (
+	excludeKey = "exclude"
+	includeKey = "include"
+)
+
+func NewIncludeFilterHelper(items []string, filterSet *filterset.Config, typ string) (filterset.FilterSet, error) {
+	return newFilterHelper(items, filterSet, includeKey, typ)
+}
+
+func NewExcludeFilterHelper(items []string, filterSet *filterset.Config, typ string) (filterset.FilterSet, error) {
+	return newFilterHelper(items, filterSet, excludeKey, typ)
+}
+
+func newFilterHelper(items []string, filterSet *filterset.Config, typ string, filterType string) (filterset.FilterSet, error) {
+	var err error
+	var filter filterset.FilterSet
+
+	if len(items) > 0 {
+		filter, err = filterset.CreateFilterSet(items, filterSet)
+		if err != nil {
+			return nil, fmt.Errorf("error creating %s %s filters: %w", filterType, typ, err)
+		}
+	}
+	return filter, nil
+}
+

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/config.go
@@ -15,7 +15,7 @@
 package filesystemscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper"
 
 import (
-	"fmt"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/filterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal"
@@ -77,32 +77,32 @@ func (cfg *Config) createFilter() (*fsFilter, error) {
 	var err error
 	filter := fsFilter{}
 
-	filter.includeDeviceFilter, err = newIncludeFilterHelper(cfg.IncludeDevices.Devices, &cfg.IncludeDevices.Config, metadata.Attributes.Device)
+	filter.includeDeviceFilter, err = filterhelper.NewIncludeFilterHelper(cfg.IncludeDevices.Devices, &cfg.IncludeDevices.Config, metadata.Attributes.Device)
 	if err != nil {
 		return nil, err
 	}
 
-	filter.excludeDeviceFilter, err = newExcludeFilterHelper(cfg.ExcludeDevices.Devices, &cfg.ExcludeDevices.Config, metadata.Attributes.Device)
+	filter.excludeDeviceFilter, err = filterhelper.NewExcludeFilterHelper(cfg.ExcludeDevices.Devices, &cfg.ExcludeDevices.Config, metadata.Attributes.Device)
 	if err != nil {
 		return nil, err
 	}
 
-	filter.includeFSTypeFilter, err = newIncludeFilterHelper(cfg.IncludeFSTypes.FSTypes, &cfg.IncludeFSTypes.Config, metadata.Attributes.Type)
+	filter.includeFSTypeFilter, err = filterhelper.NewIncludeFilterHelper(cfg.IncludeFSTypes.FSTypes, &cfg.IncludeFSTypes.Config, metadata.Attributes.Type)
 	if err != nil {
 		return nil, err
 	}
 
-	filter.excludeFSTypeFilter, err = newExcludeFilterHelper(cfg.ExcludeFSTypes.FSTypes, &cfg.ExcludeFSTypes.Config, metadata.Attributes.Type)
+	filter.excludeFSTypeFilter, err = filterhelper.NewExcludeFilterHelper(cfg.ExcludeFSTypes.FSTypes, &cfg.ExcludeFSTypes.Config, metadata.Attributes.Type)
 	if err != nil {
 		return nil, err
 	}
 
-	filter.includeMountPointFilter, err = newIncludeFilterHelper(cfg.IncludeMountPoints.MountPoints, &cfg.IncludeMountPoints.Config, metadata.Attributes.Mountpoint)
+	filter.includeMountPointFilter, err = filterhelper.NewIncludeFilterHelper(cfg.IncludeMountPoints.MountPoints, &cfg.IncludeMountPoints.Config, metadata.Attributes.Mountpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	filter.excludeMountPointFilter, err = newExcludeFilterHelper(cfg.ExcludeMountPoints.MountPoints, &cfg.ExcludeMountPoints.Config, metadata.Attributes.Mountpoint)
+	filter.excludeMountPointFilter, err = filterhelper.NewExcludeFilterHelper(cfg.ExcludeMountPoints.MountPoints, &cfg.ExcludeMountPoints.Config, metadata.Attributes.Mountpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -117,28 +117,4 @@ func (f *fsFilter) setFiltersExist() {
 		f.includeDeviceFilter != nil || f.excludeDeviceFilter != nil
 }
 
-const (
-	excludeKey = "exclude"
-	includeKey = "include"
-)
 
-func newIncludeFilterHelper(items []string, filterSet *filterset.Config, typ string) (filterset.FilterSet, error) {
-	return newFilterHelper(items, filterSet, includeKey, typ)
-}
-
-func newExcludeFilterHelper(items []string, filterSet *filterset.Config, typ string) (filterset.FilterSet, error) {
-	return newFilterHelper(items, filterSet, excludeKey, typ)
-}
-
-func newFilterHelper(items []string, filterSet *filterset.Config, typ string, filterType string) (filterset.FilterSet, error) {
-	var err error
-	var filter filterset.FilterSet
-
-	if len(items) > 0 {
-		filter, err = filterset.CreateFilterSet(items, filterSet)
-		if err != nil {
-			return nil, fmt.Errorf("error creating %s %s filters: %w", filterType, typ, err)
-		}
-	}
-	return filter, nil
-}

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/config.go
@@ -116,5 +116,3 @@ func (f *fsFilter) setFiltersExist() {
 		f.includeFSTypeFilter != nil || f.excludeFSTypeFilter != nil ||
 		f.includeDeviceFilter != nil || f.excludeDeviceFilter != nil
 }
-
-

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -36,40 +36,43 @@ type Config struct {
 	Filters []FilterConfig `mapstructure:"filters"`
 }
 
+// ExecutableNameMatchConfig filtesr by executable name
 type ExecutableNameMatchConfig struct {
 	filterset.Config `mapstructure:",squash"`
-	ExecutableNames []string `mapstructure:"executable_name"`
+	ExecutableNames  []string `mapstructure:"executable_name"`
 }
 
-
+// ExecutablePathMatchConfig filters by executable path
 type ExecutablePathMatchConfig struct {
 	filterset.Config `mapstructure:",squash"`
-	ExecutablePaths []string `mapstructure:"executable_path"`
+	ExecutablePaths  []string `mapstructure:"executable_path"`
 }
 
-
+// CommandMatchConfig filters by command
 type CommandMatchConfig struct {
 	filterset.Config `mapstructure:",squash"`
-	Commands []string `mapstructure:"process_command"`
+	Commands         []string `mapstructure:"process_command"`
 }
 
-
+// CommandLineMatchConfig filters by command line arguments
 type CommandLineMatchConfig struct {
 	filterset.Config `mapstructure:",squash"`
-	CommandLines []string `mapstructure:"process_command_line"`
+	CommandLines     []string `mapstructure:"process_command_line"`
 }
 
+// OwnerMatchConfig filters by owner
 type OwnerMatchConfig struct {
 	filterset.Config `mapstructure:",squash"`
-	Owners []string `mapstructure:"process_owner"`
+	Owners           []string `mapstructure:"process_owner"`
 }
 
+// PidMatchConfig filters by PID
 type PidMatchConfig struct {
 	filterset.Config `mapstructure:",squash"`
-	Pids []int32 `mapstructure:"process_pid"`
+	Pids             []int32 `mapstructure:"process_pid"`
 }
 
-
+// FilterConfig is used to filter processes that are reported on
 type FilterConfig struct {
 	// Include specifies a filter on the process names that should be included from the generated metrics.
 	// Exclude specifies a filter on the process names that should be excluded from the generated metrics.
@@ -79,13 +82,12 @@ type FilterConfig struct {
 	ExcludeExecutableNames ExecutableNameMatchConfig `mapstructure:"exclude_executable_name"`
 	IncludeExecutablePaths ExecutablePathMatchConfig `mapstructure:"include_executable_path"`
 	ExcludeExecutablePaths ExecutablePathMatchConfig `mapstructure:"exclude_executable_path"`
-	IncludeCommands CommandMatchConfig `mapstructure:"include_process_command"`
-	ExcludeCommands CommandMatchConfig `mapstructure:"exclude_process_command"`
-	IncludeCommandLines CommandLineMatchConfig `mapstructure:"include_process_command_line"`
-	ExcludeCommandLines CommandLineMatchConfig `mapstructure:"exclude_process_command_line"`
-	IncludeOwners OwnerMatchConfig `mapstructure:"include_process_owner"`
-	ExcludeOwners OwnerMatchConfig `mapstructure:"exclude_process_owner"`
-	IncludePids PidMatchConfig `mapstructure:"include_process_pid"`
-	ExcludePids PidMatchConfig `mapstructure:"exclude_process_pid"`
+	IncludeCommands        CommandMatchConfig        `mapstructure:"include_process_command"`
+	ExcludeCommands        CommandMatchConfig        `mapstructure:"exclude_process_command"`
+	IncludeCommandLines    CommandLineMatchConfig    `mapstructure:"include_process_command_line"`
+	ExcludeCommandLines    CommandLineMatchConfig    `mapstructure:"exclude_process_command_line"`
+	IncludeOwners          OwnerMatchConfig          `mapstructure:"include_process_owner"`
+	ExcludeOwners          OwnerMatchConfig          `mapstructure:"exclude_process_owner"`
+	IncludePids            PidMatchConfig            `mapstructure:"include_process_pid"`
+	ExcludePids            PidMatchConfig            `mapstructure:"exclude_process_pid"`
 }
-

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -87,6 +87,5 @@ type FilterConfig struct {
 	ExcludeOwners OwnerMatchConfig `mapstructure:"exclude_process_owner"`
 	IncludePids PidMatchConfig `mapstructure:"include_process_pid"`
 	ExcludePids PidMatchConfig `mapstructure:"exclude_process_pid"`
-	//	RegexpConfig *regexp.Config `mapstructure:"regexp"`
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -16,7 +16,6 @@ package processscraper // import "github.com/open-telemetry/opentelemetry-collec
 
 import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset/regexp"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
 )
@@ -27,32 +26,67 @@ type Config struct {
 
 	// Metrics allows to customize scraped metrics representation.
 	Metrics metadata.MetricsSettings `mapstructure:"metrics"`
-	// Include specifies a filter on the process names that should be included from the generated metrics.
-	// Exclude specifies a filter on the process names that should be excluded from the generated metrics.
-	// If neither `include` or `exclude` are set, process metrics will be generated for all processes.
-	Include MatchConfig `mapstructure:"include"`
-	Exclude MatchConfig `mapstructure:"exclude"`
 
 	// MuteProcessNameError is a flag that will mute the error encountered when trying to read a process the
 	// collector does not have permission for.
 	// See https://github.com/open-telemetry/opentelemetry-collector/issues/3004 for more information.
 	MuteProcessNameError bool `mapstructure:"mute_process_name_error,omitempty"`
 
+	// FilterConfig is used to filter the set of processes that are reported on
 	Filters []FilterConfig `mapstructure:"filters"`
 }
 
-type MatchConfig struct {
+type ExecutableNameMatchConfig struct {
 	filterset.Config `mapstructure:",squash"`
-
-	Names []string `mapstructure:"names"`
+	ExecutableNames []string `mapstructure:"executable_name"`
 }
+
+
+type ExecutablePathMatchConfig struct {
+	filterset.Config `mapstructure:",squash"`
+	ExecutablePaths []string `mapstructure:"executable_path"`
+}
+
+
+type CommandMatchConfig struct {
+	filterset.Config `mapstructure:",squash"`
+	Commands []string `mapstructure:"process_command"`
+}
+
+
+type CommandLineMatchConfig struct {
+	filterset.Config `mapstructure:",squash"`
+	CommandLines []string `mapstructure:"process_command_line"`
+}
+
+type OwnerMatchConfig struct {
+	filterset.Config `mapstructure:",squash"`
+	Owners []string `mapstructure:"process_owner"`
+}
+
+type PidMatchConfig struct {
+	filterset.Config `mapstructure:",squash"`
+	Pids []int32 `mapstructure:"process_pid"`
+}
+
 
 type FilterConfig struct {
-	ExecutableName string `mapstructure:"executable_name"`
-	ExecutablePath string `mapstructure:"executable_path"`
-	Command string `mapstructure:"process_command"`
-	CommandLine string `mapstructure:"process_command_line"`
-	Owner string `mapstructure:"process_owner"`
-	PID int32 `mapstructure:"process_pid"`
-	RegexpConfig *regexp.Config `mapstructure:"regexp"`
+	// Include specifies a filter on the process names that should be included from the generated metrics.
+	// Exclude specifies a filter on the process names that should be excluded from the generated metrics.
+	// If neither `include` or `exclude` are set, process metrics will be generated for all processes.
+
+	IncludeExecutableNames ExecutableNameMatchConfig `mapstructure:"include_executable_name"`
+	ExcludeExecutableNames ExecutableNameMatchConfig `mapstructure:"exclude_executable_name"`
+	IncludeExecutablePaths ExecutablePathMatchConfig `mapstructure:"include_executable_path"`
+	ExcludeExecutablePaths ExecutablePathMatchConfig `mapstructure:"exclude_executable_path"`
+	IncludeCommands CommandMatchConfig `mapstructure:"include_process_command"`
+	ExcludeCommands CommandMatchConfig `mapstructure:"exclude_process_command"`
+	IncludeCommandLines CommandLineMatchConfig `mapstructure:"include_process_command_line"`
+	ExcludeCommandLines CommandLineMatchConfig `mapstructure:"exclude_process_command_line"`
+	IncludeOwners OwnerMatchConfig `mapstructure:"include_process_owner"`
+	ExcludeOwners OwnerMatchConfig `mapstructure:"exclude_process_owner"`
+	IncludePids PidMatchConfig `mapstructure:"include_process_pid"`
+	ExcludePids PidMatchConfig `mapstructure:"exclude_process_pid"`
+	//	RegexpConfig *regexp.Config `mapstructure:"regexp"`
 }
+

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	Filters []FilterConfig `mapstructure:"filters"`
 }
 
-// ExecutableNameMatchConfig filtesr by executable name
+// ExecutableNameMatchConfig filters by executable name
 type ExecutableNameMatchConfig struct {
 	filterset.Config `mapstructure:",squash"`
 	ExecutableNames  []string `mapstructure:"executable_name"`

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter.go
@@ -1,7 +1,6 @@
 package processscraper
 
 import (
-	"fmt"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/filterhelper"
 )
@@ -49,9 +48,7 @@ func (p *processFilter) includePid(pid int32) bool {
 // int is found in the slice return true.  Otherwise return false
 func findInt (intSlice []int32, intMatch int32) bool{
 	for _, val := range intSlice {
-		fmt.Printf("comparing %v to %v\n", intMatch, val)
 		if intMatch == val {
-			fmt.Printf("match\n")
 			return true
 		}
 	}
@@ -121,7 +118,6 @@ func createFilter(filterConfig FilterConfig) (*processFilter, error) {
 
 // includeExcludeMatch checks the include and exclude filter
 func includeExcludeMatch(include filterset.FilterSet, exclude filterset.FilterSet, matchString string) bool {
-	fmt.Printf("MatchString: %s include: %v exclude:%v  includeFilterExist: %v, excludeFilterExist: %v\n", matchString, (include == nil ||  include.Matches(matchString)), (exclude == nil || !exclude.Matches(matchString)), include!=nil, exclude!= nil)
 	return (include == nil ||  include.Matches(matchString)) &&
 		(exclude == nil || !exclude.Matches(matchString))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter.go
@@ -33,7 +33,7 @@ func (p *processFilter) includeCommand(command string, commandLine string) bool 
 }
 
 // includeOwner return a boolean value indicating if owner matches the filter.
-func (p *processFilter) includeOwner (owner string) bool {
+func (p *processFilter) includeOwner(owner string) bool {
 	return includeExcludeMatch(p.includeOwnerFilter, p.excludeOwnerFilter, owner)
 }
 
@@ -43,10 +43,9 @@ func (p *processFilter) includePid(pid int32) bool {
 		(len(p.excludePidFilter) == 0 || !findInt(p.excludePidFilter, pid))
 }
 
-
 // findInt searches an int slice for a specific integeter.  If the
 // int is found in the slice return true.  Otherwise return false
-func findInt (intSlice []int32, intMatch int32) bool{
+func findInt(intSlice []int32, intMatch int32) bool {
 	for _, val := range intSlice {
 		if intMatch == val {
 			return true
@@ -118,6 +117,6 @@ func createFilter(filterConfig FilterConfig) (*processFilter, error) {
 
 // includeExcludeMatch checks the include and exclude filter
 func includeExcludeMatch(include filterset.FilterSet, exclude filterset.FilterSet, matchString string) bool {
-	return (include == nil ||  include.Matches(matchString)) &&
+	return (include == nil || include.Matches(matchString)) &&
 		(exclude == nil || !exclude.Matches(matchString))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter.go
@@ -1,112 +1,127 @@
 package processscraper
 
 import (
+	"fmt"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset/regexp"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset/strict"
-	"strings"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/filterhelper"
 )
 
-const RegExPrefix = "regex "
-
 type processFilter struct {
-	executableNameFilter filterset.FilterSet
-	executablePathFilter filterset.FilterSet
-	commandFilter        filterset.FilterSet
-	commandLineFilter    filterset.FilterSet
-	ownerFilter          filterset.FilterSet
-	pidFilter            int32
+	includeExecutableNameFilter filterset.FilterSet
+	excludeExecutableNameFilter filterset.FilterSet
+	includeExecutablePathFilter filterset.FilterSet
+	excludeExecutablePathFilter filterset.FilterSet
+	includeCommandFilter        filterset.FilterSet
+	excludeCommandFilter        filterset.FilterSet
+	includeCommandLineFilter    filterset.FilterSet
+	excludeCommandLineFilter    filterset.FilterSet
+	includeOwnerFilter          filterset.FilterSet
+	excludeOwnerFilter          filterset.FilterSet
+	includePidFilter            []int32
+	excludePidFilter            []int32
 }
 
-// MatchesExecutable return a boolean value indicating if executableName and executablePath matches the filter.
-func (p *processFilter) MatchesExecutable(executableName string, executablePath string) bool {
-	return (p.executableNameFilter == nil || p.executableNameFilter.Matches(executableName)) &&
-		(p.executablePathFilter == nil || p.executablePathFilter.Matches(executablePath))
+// includeExecutable return a boolean value indicating if executableName and executablePath matches the filter.
+func (p *processFilter) includeExecutable(executableName string, executablePath string) bool {
+	return includeExcludeMatch(p.includeExecutableNameFilter, p.excludeExecutableNameFilter, executableName) &&
+		includeExcludeMatch(p.includeExecutablePathFilter, p.excludeExecutablePathFilter, executablePath)
 }
 
-// MatchesCommand return a boolean value indicating if command and commandLine matches the filter.
-func (p *processFilter) MatchesCommand(command string, commandLine string) bool {
-	return (p.commandFilter == nil || p.commandFilter.Matches(command)) &&
-		(p.commandLineFilter == nil || p.commandLineFilter.Matches(commandLine))
+// includeCommand return a boolean value indicating if command and commandLine matches the filter.
+func (p *processFilter) includeCommand(command string, commandLine string) bool {
+	return includeExcludeMatch(p.includeCommandFilter, p.excludeCommandFilter, command) &&
+		includeExcludeMatch(p.includeCommandLineFilter, p.excludeCommandLineFilter, commandLine)
 }
-
 
 // MatchOwner return a boolean value indicating if owner matches the filter.
-func (p *processFilter) MatchOwner(owner string) bool {
-	return p.ownerFilter == nil || p.ownerFilter.Matches(owner)
+func (p *processFilter) includeOwner (owner string) bool {
+	return includeExcludeMatch(p.includeOwnerFilter, p.excludeOwnerFilter, owner)
 }
 
 // MatchesPid return a boolean value indicating if the pid matches the filter.
-func (p *processFilter) MatchesPid(pid int32) bool {
-	return p.pidFilter == 0 || (p.pidFilter == pid)
+func (p *processFilter) includePid(pid int32) bool {
+	return (len(p.includePidFilter) == 0 || findInt(p.includePidFilter, pid)) &&
+		(len(p.excludePidFilter) == 0 || !findInt(p.excludePidFilter, pid))
 }
 
-// regexParse indicates if a filter string is a regex.  The return value is
-// the filter string and a boolean indicating if the input string is a regex string.
-func regexParse(regexp string) (string, bool) {
-	// this is not a regular expression
-	if !strings.HasPrefix(regexp, RegExPrefix) {
-		return regexp, false
-	}
 
-	// trim regex indicator
-	regexp = strings.TrimPrefix(regexp, RegExPrefix)
-
-	//remove leading and trailing '"' character from a regex string
-	if len(regexp) > 1 && regexp[0] == '"' &&
-		regexp[len(regexp)-1] == '"' {
-		regexp = regexp[1:]
-		regexp = regexp[:len(regexp)-1]
+// findInt searches an int slice for a specific integeter.  If the
+// int is found in the slice return true.  Otherwise return false
+func findInt (intSlice []int32, intMatch int32) bool{
+	for _, val := range intSlice {
+		fmt.Printf("comparing %v to %v\n", intMatch, val)
+		if intMatch == val {
+			fmt.Printf("match\n")
+			return true
+		}
 	}
-	return regexp, true
+	return false
 }
 
 // createFilter receives a filter config and createa a processFilter based on the config settings
-func createFilter(filterConfig FilterConfig) (processFilter, error) {
+func createFilter(filterConfig FilterConfig) (*processFilter, error) {
 	var err error
 	filter := processFilter{}
 
-	if filterConfig.ExecutableName != "" {
-		if executableNameFilter, isRegex := regexParse(filterConfig.ExecutableName); isRegex {
-			filter.executableNameFilter, err = regexp.NewFilterSet([]string{executableNameFilter}, filterConfig.RegexpConfig)
-		} else {
-			filter.executableNameFilter = strict.NewFilterSet([]string{executableNameFilter})
-		}
+	filter.includeExecutableNameFilter, err = filterhelper.NewIncludeFilterHelper(filterConfig.IncludeExecutableNames.ExecutableNames, &filterConfig.IncludeExecutableNames.Config, "executable_name")
+	if err != nil {
+		return nil, err
 	}
 
-	if filterConfig.ExecutablePath != "" {
-		if executablePathFilter, isRegex := regexParse(filterConfig.ExecutablePath); isRegex {
-			filter.executablePathFilter, err = regexp.NewFilterSet([]string{executablePathFilter}, filterConfig.RegexpConfig)
-		} else {
-			filter.executablePathFilter = strict.NewFilterSet([]string{executablePathFilter})
-		}
+	filter.excludeExecutableNameFilter, err = filterhelper.NewExcludeFilterHelper(filterConfig.ExcludeExecutableNames.ExecutableNames, &filterConfig.ExcludeExecutableNames.Config, "executable_name")
+	if err != nil {
+		return nil, err
 	}
 
-	if filterConfig.Command != "" {
-		if commandFilter, isRegex := regexParse(filterConfig.Command); isRegex {
-			filter.commandFilter, err = regexp.NewFilterSet([]string{commandFilter}, filterConfig.RegexpConfig)
-		} else {
-			filter.commandFilter = strict.NewFilterSet([]string{commandFilter})
-		}
+	filter.includeExecutablePathFilter, err = filterhelper.NewIncludeFilterHelper(filterConfig.IncludeExecutablePaths.ExecutablePaths, &filterConfig.IncludeExecutablePaths.Config, "executable_path")
+	if err != nil {
+		return nil, err
 	}
 
-	if filterConfig.CommandLine != "" {
-		if commandLineFilter, isRegex := regexParse(filterConfig.CommandLine); isRegex {
-			filter.commandLineFilter, err = regexp.NewFilterSet([]string{commandLineFilter}, filterConfig.RegexpConfig)
-		} else {
-			filter.commandLineFilter = strict.NewFilterSet([]string{commandLineFilter})
-		}
+	filter.excludeExecutableNameFilter, err = filterhelper.NewExcludeFilterHelper(filterConfig.IncludeExecutablePaths.ExecutablePaths, &filterConfig.IncludeExecutablePaths.Config, "executable_path")
+	if err != nil {
+		return nil, err
 	}
 
-	if filterConfig.Owner != "" {
-		if ownerFilter, isRegex := regexParse(filterConfig.Owner); isRegex {
-			filter.ownerFilter, err = regexp.NewFilterSet([]string{ownerFilter}, filterConfig.RegexpConfig)
-		} else {
-			filter.ownerFilter = strict.NewFilterSet([]string{ownerFilter})
-		}
+	filter.includeCommandFilter, err = filterhelper.NewIncludeFilterHelper(filterConfig.IncludeCommands.Commands, &filterConfig.IncludeCommands.Config, "commands")
+	if err != nil {
+		return nil, err
 	}
 
-	filter.pidFilter = filterConfig.PID
+	filter.excludeCommandFilter, err = filterhelper.NewExcludeFilterHelper(filterConfig.ExcludeCommands.Commands, &filterConfig.ExcludeCommands.Config, "commands")
+	if err != nil {
+		return nil, err
+	}
 
-	return filter, err
+	filter.includeCommandLineFilter, err = filterhelper.NewIncludeFilterHelper(filterConfig.IncludeCommandLines.CommandLines, &filterConfig.IncludeCommandLines.Config, "command_lines")
+	if err != nil {
+		return nil, err
+	}
+
+	filter.excludeCommandLineFilter, err = filterhelper.NewExcludeFilterHelper(filterConfig.ExcludeCommandLines.CommandLines, &filterConfig.ExcludeCommandLines.Config, "command_lines")
+	if err != nil {
+		return nil, err
+	}
+
+	filter.includeOwnerFilter, err = filterhelper.NewIncludeFilterHelper(filterConfig.IncludeOwners.Owners, &filterConfig.IncludeOwners.Config, "owners")
+	if err != nil {
+		return nil, err
+	}
+
+	filter.excludeOwnerFilter, err = filterhelper.NewExcludeFilterHelper(filterConfig.ExcludeOwners.Owners, &filterConfig.ExcludeOwners.Config, "owners")
+	if err != nil {
+		return nil, err
+	}
+
+	filter.includePidFilter = filterConfig.IncludePids.Pids
+	filter.excludePidFilter = filterConfig.ExcludePids.Pids
+
+	return &filter, err
+}
+
+// includeExcludeMatch checks the include and exclude filter
+func includeExcludeMatch(include filterset.FilterSet, exclude filterset.FilterSet, matchString string) bool {
+	fmt.Printf("MatchString: %s include: %v exclude:%v  includeFilterExist: %v, excludeFilterExist: %v\n", matchString, (include == nil ||  include.Matches(matchString)), (exclude == nil || !exclude.Matches(matchString)), include!=nil, exclude!= nil)
+	return (include == nil ||  include.Matches(matchString)) &&
+		(exclude == nil || !exclude.Matches(matchString))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter.go
@@ -32,12 +32,12 @@ func (p *processFilter) includeCommand(command string, commandLine string) bool 
 		includeExcludeMatch(p.includeCommandLineFilter, p.excludeCommandLineFilter, commandLine)
 }
 
-// MatchOwner return a boolean value indicating if owner matches the filter.
+// includeOwner return a boolean value indicating if owner matches the filter.
 func (p *processFilter) includeOwner (owner string) bool {
 	return includeExcludeMatch(p.includeOwnerFilter, p.excludeOwnerFilter, owner)
 }
 
-// MatchesPid return a boolean value indicating if the pid matches the filter.
+// includePid return a boolean value indicating if the pid matches the filter.
 func (p *processFilter) includePid(pid int32) bool {
 	return (len(p.includePidFilter) == 0 || findInt(p.includePidFilter, pid)) &&
 		(len(p.excludePidFilter) == 0 || !findInt(p.excludePidFilter, pid))

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_set.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_set.go
@@ -32,7 +32,7 @@ func (p *processFilterSet) includeCommand(command string, commandLine string, in
 	return matches
 }
 
-// MatchesOwner returns an int array with the index of all filters that match the input owner value
+// includeOwner returns an int array with the index of all filters that match the input owner value
 // only indexes provided in indexList are checked
 func (p *processFilterSet) includeOwner(owner string, indexList []int) []int {
 	var matches []int
@@ -46,7 +46,7 @@ func (p *processFilterSet) includeOwner(owner string, indexList []int) []int {
 	return matches
 }
 
-// MatchesPid returns an int array with the index of all filters that match the input pid value
+// includePid returns an int array with the index of all filters that match the input pid value
 func (p *processFilterSet) includePid(pid int32) []int {
 	var matches []int
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_set.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_set.go
@@ -1,7 +1,7 @@
 package processscraper
 
 type processFilterSet struct {
-	filters [] processFilter
+	filters []processFilter
 }
 
 // includeExecutable returns an int array with the index of all filters that match the input executable values
@@ -76,4 +76,3 @@ func createFilters(filterConfigs []FilterConfig) (*processFilterSet, error) {
 	}
 	return &processFilterSet{filters: filters}, nil
 }
-

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_set.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_set.go
@@ -4,13 +4,13 @@ type processFilterSet struct {
 	filters [] processFilter
 }
 
-// MatchesExecutable returns an int array with the index of all filters that match the input executable values
+// includeExecutable returns an int array with the index of all filters that match the input executable values
 // only indexes provided in indexList are checked
-func (p *processFilterSet) MatchesExecutable(executableName string, executablePath string, indexList []int) []int {
+func (p *processFilterSet) includeExecutable(executableName string, executablePath string, indexList []int) []int {
 	var matches []int
 
 	for _, i := range indexList {
-		if p.filters[i].MatchesExecutable(executableName, executablePath) {
+		if p.filters[i].includeExecutable(executableName, executablePath) {
 			matches = append(matches, i)
 		}
 	}
@@ -18,13 +18,13 @@ func (p *processFilterSet) MatchesExecutable(executableName string, executablePa
 	return matches
 }
 
-// MatchesCommand returns an int array with the index of all filters that match the input command values
+// includeCommand returns an int array with the index of all filters that match the input command values
 // only indexes provided in indexList are checked
-func (p *processFilterSet) MatchesCommand(command string, commandLine string, indexList []int) []int {
+func (p *processFilterSet) includeCommand(command string, commandLine string, indexList []int) []int {
 	var matches []int
 
 	for _, i := range indexList {
-		if p.filters[i].MatchesCommand(command, commandLine) {
+		if p.filters[i].includeCommand(command, commandLine) {
 			matches = append(matches, i)
 		}
 	}
@@ -34,11 +34,11 @@ func (p *processFilterSet) MatchesCommand(command string, commandLine string, in
 
 // MatchesOwner returns an int array with the index of all filters that match the input owner value
 // only indexes provided in indexList are checked
-func (p *processFilterSet) MatchesOwner(owner string, indexList []int) []int {
+func (p *processFilterSet) includeOwner(owner string, indexList []int) []int {
 	var matches []int
 
 	for _, i := range indexList {
-		if p.filters[i].MatchOwner(owner) {
+		if p.filters[i].includeOwner(owner) {
 			matches = append(matches, i)
 		}
 	}
@@ -47,11 +47,11 @@ func (p *processFilterSet) MatchesOwner(owner string, indexList []int) []int {
 }
 
 // MatchesPid returns an int array with the index of all filters that match the input pid value
-func (p *processFilterSet) MatchesPid(pid int32) []int {
+func (p *processFilterSet) includePid(pid int32) []int {
 	var matches []int
 
 	for i, f := range p.filters {
-		if f.MatchesPid(pid) {
+		if f.includePid(pid) {
 			matches = append(matches, i)
 		}
 	}
@@ -67,7 +67,7 @@ func createFilters(filterConfigs []FilterConfig) (*processFilterSet, error) {
 		if err != nil {
 			return nil, err
 		}
-		filters = append(filters, filter)
+		filters = append(filters, *filter)
 	}
 
 	// if there are no filters, create an empty filter that matches all processes

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_set_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_set_test.go
@@ -1,6 +1,7 @@
 package processscraper
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -13,47 +14,72 @@ func TestProcNameFilter (t *testing.T) {
 	assert.Nil(t, err)
 
 	//First filter should match any command
-	matches := procFilter.MatchesCommand("anyString", "anyString", []int{0})
+	matches := procFilter.includeCommand("anyString", "anyString", []int{0})
 	assert.True(t, len(matches) == 1)
 	assert.True(t, matches[0] == 0)
 
 	filter2Config := FilterConfig{
-		Command: "command1Match",
-		CommandLine: "commandLine1Match",
+		IncludeCommands: CommandMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			Commands: []string{"command1Match"},
+		} ,
+		IncludeCommandLines: CommandLineMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			CommandLines: []string {"commandLine1Match"},
+		},
 	}
 
 	filter3Config := FilterConfig{
-		Command: "command1Match",
-		CommandLine: "",
+		IncludeCommands: CommandMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			Commands: []string{"command1Match"},
+		} ,
 	}
 
 	filter4Config := FilterConfig{
-		Command: "noMatch",
-		CommandLine: "noMatch",
+		IncludeCommands: CommandMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			Commands: []string{"noMatch"},
+		} ,
+		IncludeCommandLines: CommandLineMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			CommandLines: []string {"noMatch"},
+		},
 	}
+
 	filterConfigs = append(filterConfigs, filter2Config)
 	filterConfigs = append(filterConfigs, filter3Config)
 	filterConfigs = append(filterConfigs, filter4Config)
 	procFilter, err = createFilters(filterConfigs)
 	assert.Nil(t, err)
 
-	matches = procFilter.MatchesCommand("command1Match", "commandLine1Match", []int{0, 1, 2})
+	matches = procFilter.includeCommand("command1Match", "commandLine1Match", []int{0, 1, 2})
 	assert.True(t, len(matches) == 3)
 	assert.True(t, matches[0] == 0)
 	assert.True(t, matches[1] == 1)
 	assert.True(t, matches[2] == 2)
 
-	matches = procFilter.MatchesCommand("command1Match", "commandLine1Match", []int{1, 2})
+	matches = procFilter.includeCommand("command1Match", "commandLine1Match", []int{1, 2})
 	assert.True(t, len(matches) == 2)
 	assert.True(t, matches[0] == 1)
 	assert.True(t, matches[1] == 2)
 
-	matches = procFilter.MatchesCommand("command1Match", "noMatch", []int{0, 1, 2})
+	matches = procFilter.includeCommand("command1Match", "noMatch", []int{0, 1, 2})
 	assert.True(t, len(matches) == 2)
 	assert.True(t, matches[0] == 0)
 	assert.True(t, matches[1] == 2)
 
-	matches = procFilter.MatchesCommand("newCommand", "newCommand", []int{0, 1, 2})
+	matches = procFilter.includeCommand("newCommand", "newCommand", []int{0, 1, 2})
 	assert.True(t, len(matches) == 1)
 	assert.True(t, matches[0] == 0)
 
@@ -67,52 +93,78 @@ func TestProcExecutableFilter (t *testing.T) {
 	assert.Nil(t, err)
 
 	//First filter should match any command
-	matches := procFilter.MatchesExecutable("execName", "execPath", []int{0})
+	matches := procFilter.includeExecutable("execName", "execPath", []int{0})
 	assert.True(t, len(matches) == 1)
 	assert.True(t, matches[0] == 0)
 
-	filter1Config := FilterConfig{
-		ExecutableName: "exec1",
-		ExecutablePath: "path1",
-	}
+
 
 	filter2Config := FilterConfig{
-		ExecutableName: "exec1",
-		ExecutablePath: "",
+		IncludeExecutableNames: ExecutableNameMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			ExecutableNames: []string{"exec1"},
+		} ,
+		IncludeExecutablePaths: ExecutablePathMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			ExecutablePaths: []string {"path1"},
+		},
 	}
 
 	filter3Config := FilterConfig{
-		ExecutableName: "noMatch",
-		ExecutablePath: "noMatch",
+		IncludeExecutableNames: ExecutableNameMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			ExecutableNames: []string{"exec1"},
+		} ,
 	}
-	filterConfigs = append(filterConfigs, filter1Config)
+
+	filter4Config := FilterConfig{
+		IncludeExecutableNames: ExecutableNameMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			ExecutableNames: []string{"noMatch"},
+		} ,
+		IncludeExecutablePaths: ExecutablePathMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			ExecutablePaths: []string {"noMatch"},
+		},
+	}
+
 	filterConfigs = append(filterConfigs, filter2Config)
 	filterConfigs = append(filterConfigs, filter3Config)
+	filterConfigs = append(filterConfigs, filter4Config)
 	procFilter, err = createFilters(filterConfigs)
 	assert.Nil(t, err)
 
-	matches = procFilter.MatchesExecutable("exec1", "path1", []int{0, 1, 2})
+	matches = procFilter.includeExecutable("exec1", "path1", []int{0, 1, 2})
 	assert.True(t, len(matches) == 3)
 	assert.True(t, matches[0] == 0)
 	assert.True(t, matches[1] == 1)
 	assert.True(t, matches[2] == 2)
 
-	matches = procFilter.MatchesExecutable("exec1", "path1", []int{1, 2})
+	matches = procFilter.includeExecutable("exec1", "path1", []int{1, 2})
 	assert.True(t, len(matches) == 2)
 	assert.True(t, matches[0] == 1)
 	assert.True(t, matches[1] == 2)
 
-	matches = procFilter.MatchesExecutable("exec1", "noMatch", []int{0, 1, 2})
+	matches = procFilter.includeExecutable("exec1", "noMatch", []int{0, 1, 2})
 	assert.True(t, len(matches) == 2)
 	assert.True(t, matches[0] == 0)
 	assert.True(t, matches[1] == 2)
 
-	matches = procFilter.MatchesExecutable("newCommand", "newCommand", []int{0, 1, 2})
+	matches = procFilter.includeExecutable("newCommand", "newCommand", []int{0, 1, 2})
 	assert.True(t, len(matches) == 1)
 	assert.True(t, matches[0] == 0)
 
 }
-
 
 func TestProcOwnerFilter (t *testing.T) {
 	var filterConfigs[] FilterConfig
@@ -122,28 +174,44 @@ func TestProcOwnerFilter (t *testing.T) {
 	assert.Nil(t, err)
 
 	//First filter should match any command
-	matches := procFilter.MatchesOwner("anyUser", []int{0})
+	matches := procFilter.includeOwner("anyUser", []int{0})
 	assert.True(t, len(matches) == 1)
 	assert.True(t, matches[0] == 0)
 
-	filter1Config := FilterConfig{
-		Owner: "user1",
-	}
-
 	filter2Config := FilterConfig{
-		Owner: "user2",
+		IncludeOwners: OwnerMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			Owners: []string{"user1"},
+		} ,
 	}
 
 	filter3Config := FilterConfig{
-		Owner: RegExPrefix + "^user",
+		IncludeOwners: OwnerMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Strict,
+			},
+			Owners: []string{"user2"},
+		} ,
 	}
-	filterConfigs = append(filterConfigs, filter1Config)
+
+	filter4Config := FilterConfig{
+		IncludeOwners: OwnerMatchConfig{
+			Config: filterset.Config{
+				MatchType: filterset.Regexp,
+			},
+			Owners: []string{"^user"},
+		} ,
+	}
+
 	filterConfigs = append(filterConfigs, filter2Config)
 	filterConfigs = append(filterConfigs, filter3Config)
+	filterConfigs = append(filterConfigs, filter4Config)
 	procFilter, err = createFilters(filterConfigs)
 	assert.Nil(t, err)
 
-	matches = procFilter.MatchesOwner("user1", []int{0, 1, 2, 3})
+	matches = procFilter.includeOwner("user1", []int{0, 1, 2, 3})
 	assert.True(t, len(matches) == 3)
 	assert.True(t, matches[0] == 0)
 	assert.True(t, matches[1] == 1)
@@ -160,24 +228,28 @@ func TestProcPidFilter (t *testing.T) {
 	assert.Nil(t, err)
 
 	//First filter should match any command
-	matches := procFilter.MatchesPid(1234)
+	matches := procFilter.includePid(1234)
 	assert.True(t, len(matches) == 1)
 	assert.True(t, matches[0] == 0)
 
-	filter1Config := FilterConfig{
-		PID: 1234,
-	}
-
 	filter2Config := FilterConfig{
-		PID: 5678,
+		IncludePids: PidMatchConfig{
+			Pids: []int32 {1234},
+		},
 	}
 
-	filterConfigs = append(filterConfigs, filter1Config)
+	filter3Config := FilterConfig{
+		IncludePids: PidMatchConfig{
+			Pids: []int32 {5678},
+		},
+	}
+
 	filterConfigs = append(filterConfigs, filter2Config)
+	filterConfigs = append(filterConfigs, filter3Config)
 	procFilter, err = createFilters(filterConfigs)
 	assert.Nil(t, err)
 
-	matches = procFilter.MatchesPid(1234)
+	matches = procFilter.includePid(1234)
 	assert.True(t, len(matches) == 2)
 	assert.True(t, matches[0] == 0)
 	assert.True(t, matches[1] == 1)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_set_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_set_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func TestProcNameFilter (t *testing.T) {
-	var filterConfigs[] FilterConfig
+func TestProcNameFilter(t *testing.T) {
+	var filterConfigs []FilterConfig
 
 	filterConfigs = append(filterConfigs, FilterConfig{})
 	procFilter, err := createFilters(filterConfigs)
@@ -24,12 +24,12 @@ func TestProcNameFilter (t *testing.T) {
 				MatchType: filterset.Strict,
 			},
 			Commands: []string{"command1Match"},
-		} ,
+		},
 		IncludeCommandLines: CommandLineMatchConfig{
 			Config: filterset.Config{
 				MatchType: filterset.Strict,
 			},
-			CommandLines: []string {"commandLine1Match"},
+			CommandLines: []string{"commandLine1Match"},
 		},
 	}
 
@@ -39,7 +39,7 @@ func TestProcNameFilter (t *testing.T) {
 				MatchType: filterset.Strict,
 			},
 			Commands: []string{"command1Match"},
-		} ,
+		},
 	}
 
 	filter4Config := FilterConfig{
@@ -48,12 +48,12 @@ func TestProcNameFilter (t *testing.T) {
 				MatchType: filterset.Strict,
 			},
 			Commands: []string{"noMatch"},
-		} ,
+		},
 		IncludeCommandLines: CommandLineMatchConfig{
 			Config: filterset.Config{
 				MatchType: filterset.Strict,
 			},
-			CommandLines: []string {"noMatch"},
+			CommandLines: []string{"noMatch"},
 		},
 	}
 
@@ -85,8 +85,8 @@ func TestProcNameFilter (t *testing.T) {
 
 }
 
-func TestProcExecutableFilter (t *testing.T) {
-	var filterConfigs[] FilterConfig
+func TestProcExecutableFilter(t *testing.T) {
+	var filterConfigs []FilterConfig
 
 	filterConfigs = append(filterConfigs, FilterConfig{})
 	procFilter, err := createFilters(filterConfigs)
@@ -97,20 +97,18 @@ func TestProcExecutableFilter (t *testing.T) {
 	assert.True(t, len(matches) == 1)
 	assert.True(t, matches[0] == 0)
 
-
-
 	filter2Config := FilterConfig{
 		IncludeExecutableNames: ExecutableNameMatchConfig{
 			Config: filterset.Config{
 				MatchType: filterset.Strict,
 			},
 			ExecutableNames: []string{"exec1"},
-		} ,
+		},
 		IncludeExecutablePaths: ExecutablePathMatchConfig{
 			Config: filterset.Config{
 				MatchType: filterset.Strict,
 			},
-			ExecutablePaths: []string {"path1"},
+			ExecutablePaths: []string{"path1"},
 		},
 	}
 
@@ -120,7 +118,7 @@ func TestProcExecutableFilter (t *testing.T) {
 				MatchType: filterset.Strict,
 			},
 			ExecutableNames: []string{"exec1"},
-		} ,
+		},
 	}
 
 	filter4Config := FilterConfig{
@@ -129,12 +127,12 @@ func TestProcExecutableFilter (t *testing.T) {
 				MatchType: filterset.Strict,
 			},
 			ExecutableNames: []string{"noMatch"},
-		} ,
+		},
 		IncludeExecutablePaths: ExecutablePathMatchConfig{
 			Config: filterset.Config{
 				MatchType: filterset.Strict,
 			},
-			ExecutablePaths: []string {"noMatch"},
+			ExecutablePaths: []string{"noMatch"},
 		},
 	}
 
@@ -166,8 +164,8 @@ func TestProcExecutableFilter (t *testing.T) {
 
 }
 
-func TestProcOwnerFilter (t *testing.T) {
-	var filterConfigs[] FilterConfig
+func TestProcOwnerFilter(t *testing.T) {
+	var filterConfigs []FilterConfig
 
 	filterConfigs = append(filterConfigs, FilterConfig{})
 	procFilter, err := createFilters(filterConfigs)
@@ -184,7 +182,7 @@ func TestProcOwnerFilter (t *testing.T) {
 				MatchType: filterset.Strict,
 			},
 			Owners: []string{"user1"},
-		} ,
+		},
 	}
 
 	filter3Config := FilterConfig{
@@ -193,7 +191,7 @@ func TestProcOwnerFilter (t *testing.T) {
 				MatchType: filterset.Strict,
 			},
 			Owners: []string{"user2"},
-		} ,
+		},
 	}
 
 	filter4Config := FilterConfig{
@@ -202,7 +200,7 @@ func TestProcOwnerFilter (t *testing.T) {
 				MatchType: filterset.Regexp,
 			},
 			Owners: []string{"^user"},
-		} ,
+		},
 	}
 
 	filterConfigs = append(filterConfigs, filter2Config)
@@ -219,9 +217,8 @@ func TestProcOwnerFilter (t *testing.T) {
 
 }
 
-
-func TestProcPidFilter (t *testing.T) {
-	var filterConfigs[] FilterConfig
+func TestProcPidFilter(t *testing.T) {
+	var filterConfigs []FilterConfig
 
 	filterConfigs = append(filterConfigs, FilterConfig{})
 	procFilter, err := createFilters(filterConfigs)
@@ -234,13 +231,13 @@ func TestProcPidFilter (t *testing.T) {
 
 	filter2Config := FilterConfig{
 		IncludePids: PidMatchConfig{
-			Pids: []int32 {1234},
+			Pids: []int32{1234},
 		},
 	}
 
 	filter3Config := FilterConfig{
 		IncludePids: PidMatchConfig{
-			Pids: []int32 {5678},
+			Pids: []int32{5678},
 		},
 	}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_test.go
@@ -1,138 +1,204 @@
 package processscraper
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-func TestCommandNameFilter (t *testing.T) {
+func TestIncludeCommandNameFilter (t *testing.T) {
 	var filterConfig FilterConfig
 
-	filterConfig.Command = "stringMatch"
+	filterConfig.IncludeCommands.Commands = []string{"stringMatch"}
+	filterConfig.IncludeCommands.Config = filterset.Config{MatchType: filterset.Strict}
 	filter, err := createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match := filter.MatchesCommand("stringMatch", "")
+	match := filter.includeCommand("stringMatch", "")
 	assert.True(t, match)
 
-	match = filter.MatchesCommand("noMatch", "args")
+	match = filter.includeCommand("noMatch", "args")
 	assert.False(t, match)
 
 	// Test Regular Expression
-	filterConfig.Command = RegExPrefix + "^([a-zA-Z0-9_\\-\\.]+)TestRegex"
+	filterConfig.IncludeCommands.Commands = []string{"^([a-zA-Z0-9_\\-\\.]+)TestRegex"}
+	filterConfig.IncludeCommands.Config = filterset.Config{MatchType: filterset.Regexp}
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match = filter.MatchesCommand("astring" + "TestRegex", "--command args")
+	match = filter.includeCommand("astring" + "TestRegex", "--command args")
 	assert.True(t, match)
 
-	match = filter.MatchesCommand("astring" + "FailTest", "--command args")
-	assert.False(t, match)
-
-	// Test Regular Expression with quotes
-	filterConfig.Command = RegExPrefix + "\"^([a-zA-Z0-9_\\-\\.]+)TestRegex\""
-	filter, err = createFilter(filterConfig)
-	assert.Nil(t, err)
-
-	match = filter.MatchesCommand("astring" + "TestRegex", "--command args")
-	assert.True(t, match)
-
-	match = filter.MatchesCommand("astring" + "FailTest", "--command args")
+	match = filter.includeCommand("astring" + "FailTest", "--command args")
 	assert.False(t, match)
 
 	// Test Regular Expression with command line
-	filterConfig.Command = RegExPrefix + "\"^([a-zA-Z0-9_\\-\\.]+)TestRegex\""
-	filterConfig.CommandLine = RegExPrefix + "pas*word"
+	filterConfig.IncludeCommands.Commands = []string {"^([a-zA-Z0-9_\\-\\.]+)TestRegex"}
+	filterConfig.IncludeCommands.Config = filterset.Config{MatchType: filterset.Regexp}
+	filterConfig.IncludeCommandLines.CommandLines = []string {"pas*word"}
+	filterConfig.IncludeCommandLines.Config = filterset.Config{MatchType: filterset.Regexp}
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match = filter.MatchesCommand("astring" + "TestRegex", "passsssssword")
+	match = filter.includeCommand("astring" + "TestRegex", "passsssssword")
 	assert.True(t, match)
 
-	match = filter.MatchesCommand("NoMatchCommand", "passsssssword")
+	match = filter.includeCommand("NoMatchCommand", "passsssssword")
 	assert.False(t, match)
 
-	match = filter.MatchesCommand("astring" + "TestRegex", "NoMatchCommandLine")
+	match = filter.includeCommand("astring" + "TestRegex", "NoMatchCommandLine")
 	assert.False(t, match)
 
 }
 
+func TestExcludeCommandNameFilter (t *testing.T) {
+	var filterConfig FilterConfig
+
+	filterConfig.ExcludeCommands.Commands = []string{"stringMatch"}
+	filterConfig.ExcludeCommands.Config = filterset.Config{MatchType: filterset.Strict}
+	filter, err := createFilter(filterConfig)
+	assert.Nil(t, err)
+
+	match := filter.includeCommand("stringMatch", "")
+	assert.False(t, match)
+
+	match = filter.includeCommand("noMatch", "args")
+	assert.True(t, match)
+
+	// Test Regular Expression
+	filterConfig.ExcludeCommands.Commands = []string{"^([a-zA-Z0-9_\\-\\.]+)TestRegex"}
+	filterConfig.ExcludeCommands.Config = filterset.Config{MatchType: filterset.Regexp}
+	filter, err = createFilter(filterConfig)
+	assert.Nil(t, err)
+
+	match = filter.includeCommand("astring" + "TestRegex", "--command args")
+	assert.False(t, match)
+
+	match = filter.includeCommand("astring" + "FailTest", "--command args")
+	assert.True(t, match)
+
+	// Test Regular Expression with quotes
+	filterConfig.ExcludeCommands.Commands = []string{"^([a-zA-Z0-9_\\-\\.]+)TestRegex"}
+	filterConfig.ExcludeCommands.Config = filterset.Config{MatchType: filterset.Regexp}
+	filter, err = createFilter(filterConfig)
+	assert.Nil(t, err)
+
+	match = filter.includeCommand("astring" + "TestRegex", "--command args")
+	assert.False(t, match)
+
+	match = filter.includeCommand("astring" + "FailTest", "--command args")
+	assert.True(t, match)
+
+	// Test Regular Expression with command line
+	filterConfig.ExcludeCommands.Commands = []string {"^([a-zA-Z0-9_\\-\\.]+)TestRegex"}
+	filterConfig.ExcludeCommands.Config = filterset.Config{MatchType: filterset.Regexp}
+	filterConfig.IncludeCommandLines.CommandLines = []string {"pas*word"}
+	filterConfig.IncludeCommandLines.Config = filterset.Config{MatchType: filterset.Regexp}
+	filter, err = createFilter(filterConfig)
+	assert.Nil(t, err)
+
+	match = filter.includeCommand("astring" + "TestRegex", "passsssssword")
+	assert.False(t, match)
+
+	match = filter.includeCommand("RandomCommand", "passsssssword")
+	assert.True(t, match)
+
+}
 
 func TestPid (t *testing.T) {
 	var filterConfig FilterConfig
 
-	filterConfig.PID = 123454
+	// test include
+	filterConfig.IncludePids.Pids = []int32 {123454}
 	filter, err := createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match := filter.MatchesPid(123454)
+	match := filter.includePid(123454)
 	assert.True(t, match)
 
-	match = filter.MatchesPid(11111)
+	match = filter.includePid(11111)
 	assert.False(t, match)
+
+	// test exclude
+	filterConfig.IncludePids.Pids = []int32 {}
+	filterConfig.ExcludePids.Pids = []int32 {123454}
+	filter, err = createFilter(filterConfig)
+	assert.Nil(t, err)
+
+	match = filter.includePid(123454)
+	assert.False(t, match)
+
+	match = filter.includePid(11111)
+	assert.True(t, match)
 }
 
 func TestOwner (t *testing.T) {
 	var filterConfig FilterConfig
 
-	filterConfig.Owner = "owner"
+	filterConfig.IncludeOwners.Owners = []string {"owner"}
+	filterConfig.IncludeOwners.Config = filterset.Config{MatchType: filterset.Strict}
 	filter, err := createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match := filter.MatchOwner("owner")
+	match := filter.includeOwner("owner")
 	assert.True(t, match)
 
-	match = filter.MatchOwner("wrongowner")
+	match = filter.includeOwner("wrongowner")
 	assert.False(t, match)
 
-	filterConfig.Owner = RegExPrefix + "^owner"
+	filterConfig.IncludeOwners.Owners = []string {"^owner"}
+	filterConfig.IncludeOwners.Config = filterset.Config{MatchType: filterset.Regexp}
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match = filter.MatchOwner("ownerOwner")
+	match = filter.includeOwner("ownerOwner")
 	assert.True(t, match)
 
-	match = filter.MatchOwner("notowner")
+	match = filter.includeOwner("notowner")
 	assert.False(t, match)
 }
 
 func TestExecutable (t *testing.T) {
 	var filterConfig FilterConfig
 
-	filterConfig.ExecutableName = "executableName"
+	filterConfig.IncludeExecutableNames.ExecutableNames = []string{"executableName"}
+	filterConfig.IncludeExecutableNames.Config = filterset.Config{MatchType: filterset.Strict}
 	filter, err := createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match := filter.MatchesExecutable("executableName", "//executable//path")
+	match := filter.includeExecutable("executableName", "//executable//path")
 	assert.True(t, match)
 
-	match = filter.MatchesExecutable("noMatch", "//executable//path")
+	match = filter.includeExecutable("noMatch", "//executable//path")
 	assert.False(t, match)
 
 
-	filterConfig.ExecutableName = ""
-	filterConfig.ExecutablePath = "//executable//path"
+	filterConfig.IncludeExecutableNames = ExecutableNameMatchConfig{}
+	filterConfig.IncludeExecutablePaths.ExecutablePaths = []string{"//executable//path"}
+	filterConfig.IncludeExecutablePaths.Config = filterset.Config{MatchType: filterset.Strict}
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match = filter.MatchesExecutable("executableName", "//executable//path")
+	match = filter.includeExecutable("executableName", "//executable//path")
 	assert.True(t, match)
 
-	match = filter.MatchesExecutable("executableName", "//nomatch//path")
+	match = filter.includeExecutable("executableName", "//nomatch//path")
 	assert.False(t, match)
 
 
-	filterConfig.ExecutableName = "executableName"
-	filterConfig.ExecutablePath = "//executable//path"
+	filterConfig.IncludeExecutableNames.ExecutableNames = []string{"executableName"}
+	filterConfig.IncludeExecutableNames.Config = filterset.Config{MatchType: filterset.Strict}
+	filterConfig.IncludeExecutablePaths.ExecutablePaths = []string{"//executable//path"}
+	filterConfig.IncludeExecutablePaths.Config = filterset.Config{MatchType: filterset.Strict}
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match = filter.MatchesExecutable("executableName", "//executable//path")
+	match = filter.includeExecutable("executableName", "//executable//path")
 	assert.True(t, match)
 
-	match = filter.MatchesExecutable("executableName", "//nomatch//path")
+	match = filter.includeExecutable("executableName", "//nomatch//path")
 	assert.False(t, match)
 
-	match = filter.MatchesExecutable("noMatch", "//executable//path")
+	match = filter.includeExecutable("noMatch", "//executable//path")
 	assert.False(t, match)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_filter_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestIncludeCommandNameFilter (t *testing.T) {
+func TestIncludeCommandNameFilter(t *testing.T) {
 	var filterConfig FilterConfig
 
 	filterConfig.IncludeCommands.Commands = []string{"stringMatch"}
@@ -26,32 +26,32 @@ func TestIncludeCommandNameFilter (t *testing.T) {
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match = filter.includeCommand("astring" + "TestRegex", "--command args")
+	match = filter.includeCommand("astring"+"TestRegex", "--command args")
 	assert.True(t, match)
 
-	match = filter.includeCommand("astring" + "FailTest", "--command args")
+	match = filter.includeCommand("astring"+"FailTest", "--command args")
 	assert.False(t, match)
 
 	// Test Regular Expression with command line
-	filterConfig.IncludeCommands.Commands = []string {"^([a-zA-Z0-9_\\-\\.]+)TestRegex"}
+	filterConfig.IncludeCommands.Commands = []string{"^([a-zA-Z0-9_\\-\\.]+)TestRegex"}
 	filterConfig.IncludeCommands.Config = filterset.Config{MatchType: filterset.Regexp}
-	filterConfig.IncludeCommandLines.CommandLines = []string {"pas*word"}
+	filterConfig.IncludeCommandLines.CommandLines = []string{"pas*word"}
 	filterConfig.IncludeCommandLines.Config = filterset.Config{MatchType: filterset.Regexp}
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match = filter.includeCommand("astring" + "TestRegex", "passsssssword")
+	match = filter.includeCommand("astring"+"TestRegex", "passsssssword")
 	assert.True(t, match)
 
 	match = filter.includeCommand("NoMatchCommand", "passsssssword")
 	assert.False(t, match)
 
-	match = filter.includeCommand("astring" + "TestRegex", "NoMatchCommandLine")
+	match = filter.includeCommand("astring"+"TestRegex", "NoMatchCommandLine")
 	assert.False(t, match)
 
 }
 
-func TestExcludeCommandNameFilter (t *testing.T) {
+func TestExcludeCommandNameFilter(t *testing.T) {
 	var filterConfig FilterConfig
 
 	filterConfig.ExcludeCommands.Commands = []string{"stringMatch"}
@@ -71,10 +71,10 @@ func TestExcludeCommandNameFilter (t *testing.T) {
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match = filter.includeCommand("astring" + "TestRegex", "--command args")
+	match = filter.includeCommand("astring"+"TestRegex", "--command args")
 	assert.False(t, match)
 
-	match = filter.includeCommand("astring" + "FailTest", "--command args")
+	match = filter.includeCommand("astring"+"FailTest", "--command args")
 	assert.True(t, match)
 
 	// Test Regular Expression with quotes
@@ -83,21 +83,21 @@ func TestExcludeCommandNameFilter (t *testing.T) {
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match = filter.includeCommand("astring" + "TestRegex", "--command args")
+	match = filter.includeCommand("astring"+"TestRegex", "--command args")
 	assert.False(t, match)
 
-	match = filter.includeCommand("astring" + "FailTest", "--command args")
+	match = filter.includeCommand("astring"+"FailTest", "--command args")
 	assert.True(t, match)
 
 	// Test Regular Expression with command line
-	filterConfig.ExcludeCommands.Commands = []string {"^([a-zA-Z0-9_\\-\\.]+)TestRegex"}
+	filterConfig.ExcludeCommands.Commands = []string{"^([a-zA-Z0-9_\\-\\.]+)TestRegex"}
 	filterConfig.ExcludeCommands.Config = filterset.Config{MatchType: filterset.Regexp}
-	filterConfig.IncludeCommandLines.CommandLines = []string {"pas*word"}
+	filterConfig.IncludeCommandLines.CommandLines = []string{"pas*word"}
 	filterConfig.IncludeCommandLines.Config = filterset.Config{MatchType: filterset.Regexp}
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
-	match = filter.includeCommand("astring" + "TestRegex", "passsssssword")
+	match = filter.includeCommand("astring"+"TestRegex", "passsssssword")
 	assert.False(t, match)
 
 	match = filter.includeCommand("RandomCommand", "passsssssword")
@@ -105,11 +105,11 @@ func TestExcludeCommandNameFilter (t *testing.T) {
 
 }
 
-func TestPid (t *testing.T) {
+func TestPid(t *testing.T) {
 	var filterConfig FilterConfig
 
 	// test include
-	filterConfig.IncludePids.Pids = []int32 {123454}
+	filterConfig.IncludePids.Pids = []int32{123454}
 	filter, err := createFilter(filterConfig)
 	assert.Nil(t, err)
 
@@ -120,8 +120,8 @@ func TestPid (t *testing.T) {
 	assert.False(t, match)
 
 	// test exclude
-	filterConfig.IncludePids.Pids = []int32 {}
-	filterConfig.ExcludePids.Pids = []int32 {123454}
+	filterConfig.IncludePids.Pids = []int32{}
+	filterConfig.ExcludePids.Pids = []int32{123454}
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
 
@@ -132,10 +132,10 @@ func TestPid (t *testing.T) {
 	assert.True(t, match)
 }
 
-func TestOwner (t *testing.T) {
+func TestOwner(t *testing.T) {
 	var filterConfig FilterConfig
 
-	filterConfig.IncludeOwners.Owners = []string {"owner"}
+	filterConfig.IncludeOwners.Owners = []string{"owner"}
 	filterConfig.IncludeOwners.Config = filterset.Config{MatchType: filterset.Strict}
 	filter, err := createFilter(filterConfig)
 	assert.Nil(t, err)
@@ -146,7 +146,7 @@ func TestOwner (t *testing.T) {
 	match = filter.includeOwner("wrongowner")
 	assert.False(t, match)
 
-	filterConfig.IncludeOwners.Owners = []string {"^owner"}
+	filterConfig.IncludeOwners.Owners = []string{"^owner"}
 	filterConfig.IncludeOwners.Config = filterset.Config{MatchType: filterset.Regexp}
 	filter, err = createFilter(filterConfig)
 	assert.Nil(t, err)
@@ -158,7 +158,7 @@ func TestOwner (t *testing.T) {
 	assert.False(t, match)
 }
 
-func TestExecutable (t *testing.T) {
+func TestExecutable(t *testing.T) {
 	var filterConfig FilterConfig
 
 	filterConfig.IncludeExecutableNames.ExecutableNames = []string{"executableName"}
@@ -172,7 +172,6 @@ func TestExecutable (t *testing.T) {
 	match = filter.includeExecutable("noMatch", "//executable//path")
 	assert.False(t, match)
 
-
 	filterConfig.IncludeExecutableNames = ExecutableNameMatchConfig{}
 	filterConfig.IncludeExecutablePaths.ExecutablePaths = []string{"//executable//path"}
 	filterConfig.IncludeExecutablePaths.Config = filterset.Config{MatchType: filterset.Strict}
@@ -184,7 +183,6 @@ func TestExecutable (t *testing.T) {
 
 	match = filter.includeExecutable("executableName", "//nomatch//path")
 	assert.False(t, match)
-
 
 	filterConfig.IncludeExecutableNames.ExecutableNames = []string{"executableName"}
 	filterConfig.IncludeExecutableNames.Config = filterset.Config{MatchType: filterset.Strict}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -44,10 +44,10 @@ type scraper struct {
 	filterSet *processFilterSet
 
 	// for mocking
-	bootTime          func() (uint64, error)
-	getProcessHandles func() (processHandles, error)
+	bootTime             func() (uint64, error)
+	getProcessHandles    func() (processHandles, error)
 	getProcessExecutable func(processHandle) (*executableMetadata, error)
-	getProcessCommand func(processHandle) (*commandMetadata, error)
+	getProcessCommand    func(processHandle) (*commandMetadata, error)
 }
 
 // newProcessScraper creates a Process Scraper

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -26,7 +26,6 @@ import (
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
 )
 
@@ -43,7 +42,6 @@ type scraper struct {
 	config    *Config
 	mb        *metadata.MetricsBuilder
 	filterSet *processFilterSet
-	excludeFS filterset.FilterSet
 
 	// for mocking
 	bootTime          func() (uint64, error)
@@ -56,13 +54,6 @@ type scraper struct {
 func newProcessScraper(cfg *Config) (*scraper, error) {
 	scraper := &scraper{config: cfg, bootTime: host.BootTime, getProcessHandles: getProcessHandlesInternal}
 	var err error
-
-	if len(cfg.Exclude.Names) > 0 {
-		scraper.excludeFS, err = filterset.CreateFilterSet(cfg.Exclude.Names, &cfg.Exclude.Config)
-		if err != nil {
-			return nil, fmt.Errorf("error creating process exclude filters: %w", err)
-		}
-	}
 
 	scraper.filterSet, err = createFilters(cfg.Filters)
 	if err != nil {
@@ -144,7 +135,7 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 		pid := handles.Pid(i)
 
 		// filter by pid
-		matches := s.filterSet.MatchesPid(pid)
+		matches := s.filterSet.includePid(pid)
 		if len(matches) == 0 {
 			continue
 		}
@@ -158,7 +149,7 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 			continue
 		}
 		// filter by executable
-		matches = s.filterSet.MatchesExecutable(executable.name, executable.path, matches)
+		matches = s.filterSet.includeExecutable(executable.name, executable.path, matches)
 		if len(matches) == 0 {
 			continue
 		}
@@ -169,7 +160,7 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 		}
 		// filter by command
 		commandLine := strings.Join(command.commandLineSlice, " ")
-		matches = s.filterSet.MatchesCommand(command.command, commandLine, matches)
+		matches = s.filterSet.includeCommand(command.command, commandLine, matches)
 		if len(matches) == 0 {
 			continue
 		}
@@ -179,7 +170,7 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 			errs.AddPartial(0, fmt.Errorf("error reading username for process %q (pid %v): %w", executable.name, pid, err))
 		}
 		// filter by user
-		matches = s.filterSet.MatchesOwner(username, matches)
+		matches = s.filterSet.includeOwner(username, matches)
 		if len(matches) == 0 {
 			continue
 		}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -168,21 +168,20 @@ func TestScrapeMetrics_NewError(t *testing.T) {
 	includeFilterConfig := FilterConfig{
 		IncludeExecutableNames: ExecutableNameMatchConfig{
 			ExecutableNames: []string{"test"},
-			Config: filterset.Config{MatchType: filterset.Strict},
+			Config:          filterset.Config{MatchType: filterset.Strict},
 		},
 	}
-	_, err := newProcessScraper(&Config{Filters: []FilterConfig {includeFilterConfig}, Metrics: metadata.DefaultMetricsSettings()})
+	_, err := newProcessScraper(&Config{Filters: []FilterConfig{includeFilterConfig}, Metrics: metadata.DefaultMetricsSettings()})
 	require.Error(t, err)
 	require.Regexp(t, "^error creating process include filters:", err.Error())
-
 
 	excludeFilterConfig := FilterConfig{
 		ExcludeExecutableNames: ExecutableNameMatchConfig{
 			ExecutableNames: []string{"test"},
-			Config: filterset.Config{MatchType: filterset.Strict},
+			Config:          filterset.Config{MatchType: filterset.Strict},
 		},
 	}
-	_, err = newProcessScraper(&Config{Filters: []FilterConfig {excludeFilterConfig}, Metrics: metadata.DefaultMetricsSettings()})
+	_, err = newProcessScraper(&Config{Filters: []FilterConfig{excludeFilterConfig}, Metrics: metadata.DefaultMetricsSettings()})
 	require.Error(t, err)
 	require.Regexp(t, "^error creating process exclude filters:", err.Error())
 }
@@ -595,6 +594,6 @@ func mockGetProcessExecutable(handle processHandle) (*executableMetadata, error)
 
 func mockGetProcessCommand(handle processHandle) (*commandMetadata, error) {
 	return &commandMetadata{
-		command: "testCommand",
+		command:          "testCommand",
 		commandLineSlice: []string{"arg1", "arg2"}}, nil
 }

--- a/receiver/hostmetricsreceiver/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/testdata/config.yaml
@@ -18,9 +18,12 @@ receivers:
       paging:
       processes:
       process:
-        include:
-          names: ["test2", "test3"]
-          match_type: "regexp"
+      process:
+        filters:
+          -
+            include_executable_name:
+              match_type: "regexp"
+              executable_name: ["test2", "test3"]
 
 processors:
   nop:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Updated filter format to match other HMR receivers.
**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8188

**Testing:** <Describe what testing was performed and which tests were added.>
Ran with PID filter including only 704202 and 703606

```
{"resourceMetrics":[{"resource":{"attributes":[{"key":"process.pid","value":{"intValue":"703606"}},{"key":"process.executable.name","value":{"stringValue":"su"}},{"key":"process.executable.path","value":{"stringValue":"/usr/bin/su"}},{"key":"process.command","value":{"stringValue":"su"}},{"key":"process.command_line","value":{"stringValue":"su -"}},{"key":"process.owner","value":{"stringValue":"root"}}]},"instrumentationLibraryMetrics":[{"instrumentationLibrary":{},"metrics":[{"name":"process.cpu.time","description":"Total CPU seconds broken down by different states.","unit":"s","sum":{"dataPoints":[{"attributes":[{"key":"state","value":{"stringValue":"user"}}],"startTimeUnixNano":"1647870081000000000","timeUnixNano":"1648591863861534114","asDouble":0.03},{"attributes":[{"key":"state","value":{"stringValue":"system"}}],"startTimeUnixNano":"1647870081000000000","timeUnixNano":"1648591863861534114","asDouble":0.01},{"attributes":[{"key":"state","value":{"stringValue":"wait"}}],"startTimeUnixNano":"1647870081000000000","timeUnixNano":"1648591863861534114","asDouble":0}],"aggregationTemporality":"AGGREGATION_TEMPORALITY_CUMULATIVE","isMonotonic":true}},{"name":"process.disk.io","description":"Disk bytes transferred.","unit":"By","sum":{"dataPoints":[{"attributes":[{"key":"direction","value":{"stringValue":"read"}}],"startTimeUnixNano":"1647870081000000000","timeUnixNano":"1648591863861534114","asInt":"24576"},{"attributes":[{"key":"direction","value":{"stringValue":"write"}}],"startTimeUnixNano":"1647870081000000000","timeUnixNano":"1648591863861534114","asInt":"0"}],"aggregationTemporality":"AGGREGATION_TEMPORALITY_CUMULATIVE","isMonotonic":true}},{"name":"process.memory.physical_usage","description":"The amount of physical memory in use.","unit":"By","sum":{"dataPoints":[{"startTimeUnixNano":"1647870081000000000","timeUnixNano":"1648591863861534114","asInt":"4288512"}],"aggregationTemporality":"AGGREGATION_TEMPORALITY_CUMULATIVE"}},{"name":"process.memory.virtual_usage","description":"Virtual memory size.","unit":"By","sum":{"dataPoints":[{"startTimeUnixNano":"1647870081000000000","timeUnixNano":"1648591863861534114","asInt":"11333632"}],"aggregationTemporality":"AGGREGATION_TEMPORALITY_CUMULATIVE"}}]}],"schemaUrl":"https://opentelemetry.io/schemas/v1.6.1"}]}

```
**Documentation:** <Describe the documentation added.>
See readme